### PR TITLE
Include .well-known/apple-app-site-association

### DIFF
--- a/Discovery/Web-Content/common.txt
+++ b/Discovery/Web-Content/common.txt
@@ -3455,6 +3455,7 @@ robot
 robotics
 robots
 robots.txt
+.well-known/apple-app-site-association
 role
 roles
 roller


### PR DESCRIPTION
Include .well-known/apple-app-site-association
Ref: https://www.nccgroup.trust/us/about-us/newsroom-and-events/blog/2019/april/apples_app_site_association_the_new_robots_txt/